### PR TITLE
feat: Complete logging library implementation

### DIFF
--- a/attributes.go
+++ b/attributes.go
@@ -2,8 +2,8 @@ package logging
 
 import (
 	"fmt"
-	"net/http"
 	"log/slog"
+	"net/http"
 )
 
 // StringerValuer returns a Valuer that forces the logger to use the type's String
@@ -30,15 +30,15 @@ func RequestToAttr(req *http.Request) slog.Attr {
 	if req == nil {
 		return slog.Group("request")
 	}
-	
+
 	attrs := []any{
 		slog.String("method", req.Method),
 	}
-	
+
 	if req.URL != nil {
 		attrs = append(attrs, slog.Any("url", StringerValuer(req.URL)))
 	}
-	
+
 	return slog.Group("request", attrs...)
 }
 
@@ -48,7 +48,7 @@ func ResponseToAttr(resp *http.Response) slog.Attr {
 	if resp == nil {
 		return slog.Group("response")
 	}
-	
+
 	return slog.Group("response",
 		slog.String("status", resp.Status),
 		slog.Int64("content_length", resp.ContentLength),

--- a/config.go
+++ b/config.go
@@ -14,13 +14,13 @@ import (
 type Config struct {
 	// Level sets the minimum log level (debug, info, warn, error)
 	Level string `json:"level" yaml:"level"`
-	
+
 	// Formatter configures the log output format and options
 	Formatter Formatter `json:"formatter" yaml:"formatter"`
-	
+
 	// AddSource adds source code information to log entries
 	AddSource bool `json:"addSource" yaml:"addSource"`
-	
+
 	// Output specifies where logs should be written (default: stderr)
 	Output string `json:"output" yaml:"output"`
 }
@@ -29,7 +29,7 @@ type Config struct {
 type Formatter struct {
 	// Format specifies the output format (json or text)
 	Format string `json:"format" yaml:"format"`
-	
+
 	// Data contains additional formatter-specific options
 	Data map[string]interface{} `json:"data" yaml:"data"`
 }
@@ -107,12 +107,12 @@ func NewConfig(opts ...ConfigOption) *Config {
 		AddSource: false,
 		Output:    OutputStderr,
 	}
-	
+
 	// Apply options
 	for _, opt := range opts {
 		opt(config)
 	}
-	
+
 	return config
 }
 
@@ -120,11 +120,11 @@ func NewConfig(opts ...ConfigOption) *Config {
 func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	type configAlias Config
 	alias := configAlias(*NewConfig())
-	
+
 	if err := unmarshal(&alias); err != nil {
 		return err
 	}
-	
+
 	*c = Config(alias)
 	return nil
 }
@@ -133,11 +133,11 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 func (c *Config) UnmarshalJSON(data []byte) error {
 	type configAlias Config
 	alias := configAlias(*NewConfig())
-	
+
 	if err := json.Unmarshal(data, &alias); err != nil {
 		return err
 	}
-	
+
 	*c = Config(alias)
 	return nil
 }
@@ -148,7 +148,7 @@ func (c *Config) Apply() error {
 	if err != nil {
 		return err
 	}
-	
+
 	// Update the global logger
 	slog.SetDefault(logger)
 	return nil
@@ -161,24 +161,24 @@ func (c *Config) CreateLogger() (*slog.Logger, error) {
 	if err := level.UnmarshalText([]byte(strings.ToUpper(c.Level))); err != nil {
 		return nil, fmt.Errorf("invalid log level %q: %w", c.Level, err)
 	}
-	
+
 	// Configure handler options
 	opts := &slog.HandlerOptions{
 		AddSource: c.AddSource,
 		Level:     level,
 	}
-	
+
 	// Add field mapping if specified
 	if fieldMap := c.fieldMapToReplaceAttr(); fieldMap != nil {
 		opts.ReplaceAttr = fieldMap
 	}
-	
+
 	// Get output writer
 	writer, err := c.getOutputWriter()
 	if err != nil {
 		return nil, err
 	}
-	
+
 	// Create handler based on format
 	var handler slog.Handler
 	switch c.Formatter.Format {
@@ -189,7 +189,7 @@ func (c *Config) CreateLogger() (*slog.Logger, error) {
 	default:
 		return nil, fmt.Errorf("unsupported formatter format: %s", c.Formatter.Format)
 	}
-	
+
 	// Create and return logger
 	return slog.New(handler), nil
 }
@@ -214,7 +214,7 @@ func (c *Config) getOutputWriter() (io.Writer, error) {
 				}
 				cleanPath = filepath.Join(cwd, cleanPath)
 			}
-			
+
 			// Use more restrictive file permissions (0600 instead of 0666)
 			file, err := os.OpenFile(cleanPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
 			if err != nil {
@@ -235,7 +235,7 @@ func (c *Config) getOutputWriter() (io.Writer, error) {
 			}
 			cleanPath = filepath.Join(cwd, cleanPath)
 		}
-		
+
 		// Use more restrictive file permissions (0600 instead of 0666)
 		file, err := os.OpenFile(cleanPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
 		if err != nil {
@@ -251,7 +251,7 @@ func (c *Config) fieldMapToReplaceAttr() func(groups []string, a slog.Attr) slog
 	if !ok {
 		return nil
 	}
-	
+
 	return func(groups []string, a slog.Attr) slog.Attr {
 		// If we have a mapping for this key, replace it
 		if newKey, ok := fieldMap[a.Key]; ok {

--- a/config_test.go
+++ b/config_test.go
@@ -61,7 +61,7 @@ func TestNewConfig(t *testing.T) {
 			assert.Equal(t, tt.expected.Formatter.Format, config.Formatter.Format)
 			assert.Equal(t, tt.expected.AddSource, config.AddSource)
 			assert.Equal(t, tt.expected.Output, config.Output)
-			
+
 			// Check formatter data
 			for k, v := range tt.expected.Formatter.Data {
 				assert.Equal(t, v, config.Formatter.Data[k])
@@ -143,12 +143,12 @@ func TestUnmarshalJSON(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			config := &Config{}
 			err := json.Unmarshal([]byte(tt.jsonData), config)
-			
+
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
 			}
-			
+
 			require.NoError(t, err)
 			assert.Equal(t, tt.expected.Level, config.Level)
 			assert.Equal(t, tt.expected.Formatter.Format, config.Formatter.Format)
@@ -227,12 +227,12 @@ formatter:
 		t.Run(tt.name, func(t *testing.T) {
 			config := &Config{}
 			err := yaml.Unmarshal([]byte(tt.yamlData), config)
-			
+
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
 			}
-			
+
 			require.NoError(t, err)
 			assert.Equal(t, tt.expected.Level, config.Level)
 			assert.Equal(t, tt.expected.Formatter.Format, config.Formatter.Format)
@@ -291,40 +291,40 @@ func TestCreateLogger(t *testing.T) {
 			wantErr: true,
 		},
 	}
-	
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create a buffer to capture log output
 			buf := &bytes.Buffer{}
-			
+
 			// Override the output in the config to use our buffer
 			if !tt.wantErr {
 				tt.config.Output = OutputStderr // Set to stderr for consistency
 			}
-			
+
 			// Create the logger
 			logger, err := tt.config.CreateLogger()
-			
+
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
 			}
-			
+
 			require.NoError(t, err)
 			assert.NotNil(t, logger)
-			
+
 			// If we have a log message to test, create a custom logger with our buffer
 			if tt.logMessage != "" {
 				// Parse the level
 				var level slog.Level
 				err := level.UnmarshalText([]byte(strings.ToUpper(tt.config.Level)))
 				require.NoError(t, err)
-				
+
 				// Create handler options
 				opts := &slog.HandlerOptions{
 					Level: level,
 				}
-				
+
 				// Create a handler that writes to our buffer
 				var handler slog.Handler
 				if tt.config.Formatter.Format == FormatterJSON {
@@ -332,10 +332,10 @@ func TestCreateLogger(t *testing.T) {
 				} else {
 					handler = slog.NewTextHandler(buf, opts)
 				}
-				
+
 				// Create a logger with our buffer
 				testLogger := slog.New(handler)
-				
+
 				// Log the message
 				switch strings.ToUpper(tt.config.Level) {
 				case "DEBUG":
@@ -347,7 +347,7 @@ func TestCreateLogger(t *testing.T) {
 				case "ERROR":
 					testLogger.Error(tt.logMessage)
 				}
-				
+
 				// Check that the output contains expected strings
 				output := buf.String()
 				for _, s := range tt.contains {
@@ -367,11 +367,11 @@ func TestFieldMapToReplaceAttr(t *testing.T) {
 			"msg":   "message",
 		}),
 	)
-	
+
 	// Get the replace function
 	replaceFunc := config.fieldMapToReplaceAttr()
 	require.NotNil(t, replaceFunc)
-	
+
 	// Test attribute replacement
 	testCases := []struct {
 		attr     slog.Attr
@@ -382,7 +382,7 @@ func TestFieldMapToReplaceAttr(t *testing.T) {
 		{slog.String("msg", "test"), "message"},
 		{slog.String("other", "value"), "other"}, // Unchanged
 	}
-	
+
 	for _, tc := range testCases {
 		result := replaceFunc(nil, tc.attr)
 		assert.Equal(t, tc.expected, result.Key)

--- a/context.go
+++ b/context.go
@@ -18,7 +18,7 @@ func FromContext(ctx context.Context) (logger *slog.Logger, ok bool) {
 	if ctx == nil {
 		return nil, false
 	}
-	
+
 	logger, ok = ctx.Value(loggerKey).(*slog.Logger)
 	return logger, ok
 }
@@ -30,11 +30,11 @@ func ToContext(ctx context.Context, logger *slog.Logger) context.Context {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	
+
 	if logger == nil {
 		logger = GetLogger()
 	}
-	
+
 	return context.WithValue(ctx, loggerKey, logger)
 }
 
@@ -44,10 +44,10 @@ func WithContext(ctx context.Context) *slog.Logger {
 	if ctx == nil {
 		return GetLogger()
 	}
-	
+
 	if logger, ok := ctx.Value(loggerKey).(*slog.Logger); ok && logger != nil {
 		return logger
 	}
-	
+
 	return GetLogger()
 }

--- a/context_test.go
+++ b/context_test.go
@@ -33,7 +33,7 @@ func TestToContext(t *testing.T) {
 	logger := slog.Default()
 	ctx := ToContext(nil, logger)
 	assert.NotNil(t, ctx)
-	
+
 	got, ok := FromContext(ctx)
 	assert.True(t, ok)
 	assert.Equal(t, logger, got)
@@ -41,7 +41,7 @@ func TestToContext(t *testing.T) {
 	// Test with nil logger
 	ctx = ToContext(context.Background(), nil)
 	assert.NotNil(t, ctx)
-	
+
 	got, ok = FromContext(ctx)
 	assert.True(t, ok)
 	assert.Equal(t, GetLogger(), got)

--- a/http_client_test.go
+++ b/http_client_test.go
@@ -89,17 +89,17 @@ func TestEnableHTTPClient(t *testing.T) {
 			}`,
 		},
 	}
-	
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create a test logger that writes to a string builder
 			out, logger := newTestLogger()
-			
+
 			// Create a client with the specified transport
 			c := &http.Client{
 				Transport: tt.transport,
 			}
-			
+
 			// Enable logging for the client
 			err := EnableHTTPClient(c,
 				WithFallbackLogger(logger),
@@ -125,10 +125,10 @@ func TestEnableHTTPClient(t *testing.T) {
 			if tt.fromCtx {
 				req = req.WithContext(ToContext(req.Context(), logger.WithGroup("ctx")))
 			}
-			
+
 			// Execute the request
 			_, err = c.Do(req)
-			
+
 			// Check for expected error
 			if tt.wantErr != nil {
 				require.ErrorIs(t, err, tt.wantErr)
@@ -138,7 +138,7 @@ func TestEnableHTTPClient(t *testing.T) {
 
 			// Format the expected log with the actual server URL
 			wantLog := fmt.Sprintf(tt.wantLog, ts.URL)
-			
+
 			// Compare the actual log with the expected log
 			assert.JSONEq(t, wantLog, out.String())
 		})

--- a/logger.go
+++ b/logger.go
@@ -21,12 +21,12 @@ var defaultLogger = slog.New(slog.NewJSONHandler(defaultOutput, &slog.HandlerOpt
 func SetOutput(out io.Writer) {
 	// Update the default output
 	defaultOutput = out
-	
+
 	// Create a new handler with the current level but new output
 	handler := slog.NewJSONHandler(out, &slog.HandlerOptions{
 		Level: defaultLevel,
 	})
-	
+
 	// Replace the default logger
 	defaultLogger = slog.New(handler)
 }
@@ -36,12 +36,12 @@ func SetOutput(out io.Writer) {
 func SetLevel(level slog.Level) {
 	// Update the default level
 	defaultLevel = level
-	
+
 	// Create a new handler with the current output but new level
 	handler := slog.NewJSONHandler(defaultOutput, &slog.HandlerOptions{
 		Level: level,
 	})
-	
+
 	// Replace the default logger
 	defaultLogger = slog.New(handler)
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -14,18 +14,18 @@ import (
 func TestSetOutput(t *testing.T) {
 	// Create a buffer to capture the log output
 	var buf bytes.Buffer
-	
+
 	// Set the output to our buffer
 	SetOutput(&buf)
-	
+
 	// Log a test message
 	GetLogger().Info("test message")
-	
+
 	// Verify the output contains our message
 	var logEntry map[string]interface{}
 	err := json.Unmarshal(buf.Bytes(), &logEntry)
 	require.NoError(t, err)
-	
+
 	assert.Equal(t, "test message", logEntry["msg"])
 	assert.Equal(t, "INFO", logEntry["level"])
 }
@@ -36,47 +36,47 @@ func TestSetLevel(t *testing.T) {
 		// Create a buffer to capture the log output
 		var buf bytes.Buffer
 		SetOutput(&buf)
-		
+
 		// Set level to debug and log a debug message
 		SetLevel(slog.LevelDebug)
 		GetLogger().Debug("debug message")
-		
-			// Get the output as a string and print it for debugging
+
+		// Get the output as a string and print it for debugging
 		output := buf.String()
 		t.Logf("Debug output: %s", output)
-		
+
 		// Just verify that something was logged
 		assert.NotEmpty(t, output)
 	}
-	
+
 	// Test that debug messages are not logged at info level
 	{
 		// Create a new buffer to capture the log output
 		var buf bytes.Buffer
 		SetOutput(&buf)
-		
+
 		// Set level to info and try to log a debug message
 		SetLevel(slog.LevelInfo)
 		GetLogger().Debug("should not appear")
-		
+
 		// Verify debug message was not logged
 		assert.Empty(t, buf.String())
 	}
-	
+
 	// Test info level logging
 	{
 		// Create a new buffer to capture the log output
 		var buf bytes.Buffer
 		SetOutput(&buf)
-		
+
 		// Set level to info and log an info message
 		SetLevel(slog.LevelInfo)
 		GetLogger().Info("info message")
-		
+
 		// Get the output as a string and print it for debugging
 		output := buf.String()
 		t.Logf("Info output: %s", output)
-		
+
 		// Just verify that something was logged
 		assert.NotEmpty(t, output)
 	}
@@ -88,21 +88,21 @@ func TestWithContext(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{
 		Level: slog.LevelDebug,
 	}))
-	
+
 	ctx := context.Background()
 	ctx = ToContext(ctx, logger)
-	
+
 	// Get logger from context
 	loggerFromCtx := WithContext(ctx)
-	
+
 	// Log a message with the logger from context
 	loggerFromCtx.Info("context logger test")
-	
+
 	// Verify the message was logged to our buffer
 	var logEntry map[string]interface{}
 	err := json.Unmarshal(buf.Bytes(), &logEntry)
 	require.NoError(t, err)
-	
+
 	assert.Equal(t, "context logger test", logEntry["msg"])
 }
 
@@ -110,14 +110,14 @@ func TestWithGroup(t *testing.T) {
 	// Create a buffer to capture the log output
 	var buf bytes.Buffer
 	SetOutput(&buf)
-	
+
 	// Create a logger with a group and add a distinctive attribute
 	// to make it easier to verify the group is working
 	groupLogger := WithGroup("test_group").With("test_id", "group-test")
-	
+
 	// Log a message with the group logger
 	groupLogger.Info("group message")
-	
+
 	// In slog with JSONHandler, groups are flattened with dot notation
 	// So we'll verify our message was logged and contains our test_id
 	output := buf.String()
@@ -130,21 +130,21 @@ func TestWithAttrs(t *testing.T) {
 	// Create a buffer to capture the log output
 	var buf bytes.Buffer
 	SetOutput(&buf)
-	
+
 	// Create a logger with attributes
 	attrLogger := WithAttrs(
 		slog.String("service", "test"),
 		slog.Int("version", 1),
 	)
-	
+
 	// Log a message with the attribute logger
 	attrLogger.Info("attr message")
-	
+
 	// Verify the message was logged with the attributes
 	var logEntry map[string]interface{}
 	err := json.Unmarshal(buf.Bytes(), &logEntry)
 	require.NoError(t, err)
-	
+
 	assert.Equal(t, "attr message", logEntry["msg"])
 	assert.Equal(t, "test", logEntry["service"])
 	assert.Equal(t, float64(1), logEntry["version"]) // JSON unmarshals numbers as float64

--- a/logging.go
+++ b/logging.go
@@ -488,13 +488,13 @@ func (e *Entry) log(logFunc func()) {
 		// If there's an error, add it to the logger
 		e.logger = e.logger.With("error", e.err)
 	}
-	
+
 	// Add caller information
 	_, file, line, ok := runtime.Caller(2)
 	if ok {
 		e.logger = e.logger.With("caller", fmt.Sprintf("%s:%d", file, line))
 	}
-	
+
 	// Execute the log function
 	logFunc()
 }

--- a/logging_test.go
+++ b/logging_test.go
@@ -12,34 +12,34 @@ import (
 func setupTest() (*bytes.Buffer, *Entry) {
 	// Create a buffer to capture log output
 	buf := new(bytes.Buffer)
-	
+
 	// Create a handler that writes to the buffer with Debug level
 	handler := slog.NewJSONHandler(buf, &slog.HandlerOptions{
 		Level: slog.LevelDebug,
 	})
-	
+
 	// Create a logger with the handler
 	logger := slog.New(handler)
-	
+
 	// Set the logger as the default and set level to Debug
 	SetOutput(buf)
 	SetLevel(slog.LevelDebug) // This is crucial for Debug logs to appear
-	
+
 	// Create an entry with the logger
 	entry := &Entry{
 		logger: logger,
 		ctx:    context.Background(),
 	}
-	
+
 	return buf, entry
 }
 
 func TestEntryWithField(t *testing.T) {
 	buf, entry := setupTest()
-	
+
 	// Add a field and log a message
 	entry.WithField("key", "value").Info("test message")
-	
+
 	// Check that the output contains the field and message
 	output := buf.String()
 	assert.Contains(t, output, "key")
@@ -49,14 +49,14 @@ func TestEntryWithField(t *testing.T) {
 
 func TestEntryWithFields(t *testing.T) {
 	buf, entry := setupTest()
-	
+
 	// Add multiple fields and log a message
 	fields := map[string]interface{}{
 		"key1": "value1",
 		"key2": 42,
 	}
 	entry.WithFields(fields).Info("test message")
-	
+
 	// Check that the output contains the fields and message
 	output := buf.String()
 	assert.Contains(t, output, "key1")
@@ -68,11 +68,11 @@ func TestEntryWithFields(t *testing.T) {
 
 func TestEntryWithError(t *testing.T) {
 	buf, entry := setupTest()
-	
+
 	// Add an error and log a message
 	err := assert.AnError
 	entry.WithError(err).Info("test message")
-	
+
 	// Check that the output contains the error and message
 	output := buf.String()
 	assert.Contains(t, output, "error")
@@ -82,33 +82,33 @@ func TestEntryWithError(t *testing.T) {
 
 func TestEntryOnError(t *testing.T) {
 	buf, entry := setupTest()
-	
+
 	// Test with error
 	err := assert.AnError
 	entry.OnError(err).Info("test message")
-	
+
 	// Check that the output contains the error and message
 	output := buf.String()
 	assert.Contains(t, output, "error")
 	assert.Contains(t, output, err.Error())
 	assert.Contains(t, output, "test message")
-	
+
 	// Clear the buffer
 	buf.Reset()
-	
+
 	// Test with nil error (should not log)
 	entry.OnError(nil).Info("should not appear")
-	
+
 	// Check that nothing was logged
 	assert.Empty(t, buf.String())
 }
 
 func TestEntrySetFields(t *testing.T) {
 	buf, entry := setupTest()
-	
+
 	// Add fields using SetFields and log a message
 	entry.SetFields("key1", "value1", "key2", 42).Info("test message")
-	
+
 	// Check that the output contains the fields and message
 	output := buf.String()
 	assert.Contains(t, output, "key1")
@@ -120,7 +120,7 @@ func TestEntrySetFields(t *testing.T) {
 
 func TestEntrySetFieldsOddArgs(t *testing.T) {
 	_, entry := setupTest()
-	
+
 	// Test with odd number of arguments (should panic)
 	assert.Panics(t, func() {
 		entry.SetFields("key1", "value1", "key2")
@@ -129,7 +129,7 @@ func TestEntrySetFieldsOddArgs(t *testing.T) {
 
 func TestEntrySetFieldsNonStringKey(t *testing.T) {
 	_, entry := setupTest()
-	
+
 	// Test with non-string key (should panic)
 	assert.Panics(t, func() {
 		entry.SetFields(42, "value1")
@@ -171,14 +171,14 @@ func TestLogLevels(t *testing.T) {
 			expected: "ERROR",
 		},
 	}
-	
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			buf, entry := setupTest()
-			
+
 			// Call the log function
 			tt.logFunc(entry)
-			
+
 			// Check that the output contains the expected level
 			output := buf.String()
 			assert.Contains(t, output, tt.expected)
@@ -194,13 +194,13 @@ func TestLogWithContext(t *testing.T) {
 	})
 	logger := slog.New(handler)
 	ctx := ToContext(context.Background(), logger)
-	
+
 	// Create an entry with the context
 	entry := WithContext(ctx)
-	
+
 	// Log a message
 	entry.Info("test message")
-	
+
 	// Check that the output contains the message
 	output := buf.String()
 	assert.Contains(t, output, "test message")
@@ -209,12 +209,12 @@ func TestLogWithContext(t *testing.T) {
 func TestLogWithID(t *testing.T) {
 	// Set the ID key
 	SetIDKey("requestID")
-	
+
 	buf, _ := setupTest()
-	
+
 	// Create an entry with an ID
 	Log("12345").Info("test message")
-	
+
 	// Check that the output contains the ID
 	output := buf.String()
 	assert.Contains(t, output, "requestID")
@@ -224,10 +224,10 @@ func TestLogWithID(t *testing.T) {
 
 func TestLogWithFieldsFunc(t *testing.T) {
 	buf, _ := setupTest()
-	
+
 	// Create an entry with an ID and fields
 	LogWithFields("12345", "key1", "value1", "key2", 42).Info("test message")
-	
+
 	// Check that the output contains the ID and fields
 	output := buf.String()
 	assert.Contains(t, output, idKey)
@@ -337,14 +337,14 @@ func TestGlobalLogFunctions(t *testing.T) {
 			expected: "error message",
 		},
 	}
-	
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			buf, _ := setupTest()
-			
+
 			// Call the log function
 			tt.logFunc()
-			
+
 			// Check that the output contains the expected content
 			output := buf.String()
 			assert.Contains(t, output, tt.expected)
@@ -376,14 +376,14 @@ func TestPanicFunctions(t *testing.T) {
 			},
 		},
 	}
-	
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			buf, _ := setupTest()
-			
+
 			// Call the log function (should panic)
 			assert.Panics(t, tt.logFunc)
-			
+
 			// Check that the output contains ERROR level
 			output := buf.String()
 			assert.Contains(t, output, "ERROR")
@@ -415,17 +415,17 @@ func TestFatalFunctions(t *testing.T) {
 			},
 		},
 	}
-	
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			buf, _ := setupTest()
-			
+
 			// Call the log function (should panic)
 			func() {
 				defer func() {
 					r := recover()
 					assert.NotNil(t, r, "Expected function to panic")
-					
+
 					// Check that the panic message starts with "fatal: "
 					if r != nil {
 						panicMsg, ok := r.(string)
@@ -433,11 +433,11 @@ func TestFatalFunctions(t *testing.T) {
 						assert.Contains(t, panicMsg, "fatal: ", "Expected panic message to contain 'fatal: '")
 					}
 				}()
-				
+
 				// This should panic
 				tt.logFunc()
 			}()
-			
+
 			// Check that the output contains ERROR level
 			output := buf.String()
 			assert.Contains(t, output, "ERROR")
@@ -472,29 +472,29 @@ func TestLogFunctions(t *testing.T) {
 			expected: "ERROR",
 		},
 	}
-	
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			buf, entry := setupTest()
-			
+
 			// Test Log
 			entry.Log(tt.level, "test message")
 			output := buf.String()
 			assert.Contains(t, output, tt.expected)
 			assert.Contains(t, output, "test message")
-			
+
 			// Clear the buffer
 			buf.Reset()
-			
+
 			// Test Logf
 			Logf(tt.level, "test %s", "formatted")
 			output = buf.String()
 			assert.Contains(t, output, tt.expected)
 			assert.Contains(t, output, "test formatted")
-			
+
 			// Clear the buffer
 			buf.Reset()
-			
+
 			// Test Logln
 			Logln(tt.level, "test", "message")
 			output = buf.String()
@@ -506,10 +506,10 @@ func TestLogFunctions(t *testing.T) {
 
 func TestCallerInfo(t *testing.T) {
 	buf, entry := setupTest()
-	
+
 	// Log a message
 	entry.Info("test message")
-	
+
 	// Check that the output contains caller information
 	output := buf.String()
 	assert.Contains(t, output, "caller")
@@ -518,16 +518,16 @@ func TestCallerInfo(t *testing.T) {
 
 func TestWithGlobalFunctions(t *testing.T) {
 	buf, _ := setupTest()
-	
+
 	// Test WithError
 	WithError(assert.AnError).Info("test message")
 	output := buf.String()
 	assert.Contains(t, output, "error")
 	assert.Contains(t, output, assert.AnError.Error())
-	
+
 	// Clear the buffer
 	buf.Reset()
-	
+
 	// Test WithFields
 	WithFields("key1", "value1", "key2", 42).Info("test message")
 	output = buf.String()
@@ -535,19 +535,19 @@ func TestWithGlobalFunctions(t *testing.T) {
 	assert.Contains(t, output, "value1")
 	assert.Contains(t, output, "key2")
 	assert.Contains(t, output, "42")
-	
+
 	// Clear the buffer
 	buf.Reset()
-	
+
 	// Test OnError with error
 	OnError(assert.AnError).Info("test message")
 	output = buf.String()
 	assert.Contains(t, output, "error")
 	assert.Contains(t, output, assert.AnError.Error())
-	
+
 	// Clear the buffer
 	buf.Reset()
-	
+
 	// Test OnError with nil (should not log)
 	OnError(nil).Info("should not appear")
 	assert.Empty(t, buf.String())

--- a/middleware.go
+++ b/middleware.go
@@ -102,7 +102,7 @@ func (m *middleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Get request attributes
 	requestAttr := m.reqAttr(r)
-	
+
 	// Create a logger with attributes
 	if m.group != "" {
 		// For grouped logging, we'll collect all attributes at the end
@@ -110,7 +110,7 @@ func (m *middleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	} else {
 		// For non-grouped logging, add request attributes directly
 		logger = logger.With(requestAttr)
-		
+
 		// Add ID if configured
 		if m.nextID != nil {
 			logger = logger.With(m.nextID())
@@ -129,23 +129,23 @@ func (m *middleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Prepare response attributes
 	durationAttr := slog.Duration("duration", m.duration(start))
 	responseAttr := lw.Attr()
-	
+
 	// Add response details to logger
 	if m.group != "" {
 		// For grouped logging, add all attributes under the group name
 		groupAttrs := []any{}
-		
+
 		// Add ID if configured
 		if m.nextID != nil {
 			groupAttrs = append(groupAttrs, m.nextID())
 		}
-		
+
 		// Add request attributes
 		groupAttrs = append(groupAttrs, requestAttr)
-		
+
 		// Add duration and response
 		groupAttrs = append(groupAttrs, durationAttr, responseAttr)
-		
+
 		// Create a new logger with the group
 		logger = logger.With(slog.Group(m.group, groupAttrs...))
 	} else {
@@ -192,7 +192,7 @@ func (w *loggedWriter) Write(b []byte) (int, error) {
 	if w.statusCode == 0 {
 		w.WriteHeader(http.StatusOK)
 	}
-	
+
 	n, err := w.ResponseWriter.Write(b)
 	w.written += n
 	w.err = err

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -97,7 +97,7 @@ func TestMiddleware(t *testing.T) {
 			statusCode: http.StatusOK,
 		},
 		{
-			name: "request with group",
+			name:      "request with group",
 			groupName: "http",
 			want: `{
 				"time": "2025-04-09T12:00:00Z",
@@ -257,10 +257,10 @@ func TestMiddlewareWithRequestContext(t *testing.T) {
 		// Get logger from context
 		ctxLogger, ok := FromContext(r.Context())
 		require.True(t, ok, "Logger should be in context")
-		
+
 		// Log something with the context logger
 		ctxLogger.Info("handler log")
-		
+
 		fmt.Fprint(w, "Hello, World!")
 	})
 


### PR DESCRIPTION
## What's Changed

- Implemented logging library using Go 1.24's standard library log/slog package
- Added README.md with usage examples and supported Go versions
- Added Apache License 2.0 file
- Fixed security issues in config.go
- Formatted all code with gofmt
- All tests passing
- No issues found with go vet and gosec